### PR TITLE
Do not encode uint64 as an integer

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -1101,7 +1101,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
 - (void)encodeWithCoder:(NSCoder *)coder {
     [super encodeWithCoder:coder];
 
-    [coder encodeInteger:self.dataDetectorTypes forKey:@"dataDetectorTypes"];
+    [coder encodeInt64:self.dataDetectorTypes forKey:@"dataDetectorTypes"];
     [coder encodeObject:self.links forKey:@"links"];
     if ([NSMutableParagraphStyle class]) {
         [coder encodeObject:self.linkAttributes forKey:@"linkAttributes"];
@@ -1129,7 +1129,7 @@ afterInheritingLabelAttributesAndConfiguringWithBlock:(NSMutableAttributedString
     [self commonInit];
 
     if ([coder containsValueForKey:@"dataDetectorTypes"]) {
-        self.dataDetectorTypes = [coder decodeIntegerForKey:@"dataDetectorTypes"];
+        self.dataDetectorTypes = [coder decodeInt64ForKey:@"dataDetectorTypes"];
     }
 
     if ([coder containsValueForKey:@"links"]) {


### PR DESCRIPTION
Encode/decode as int64 instead and kill an Xcode warning.

/cc @efirestone @kyleve
